### PR TITLE
fix verify request missing access token

### DIFF
--- a/apps/operator/src/app/(auth)/verify/page.tsx
+++ b/apps/operator/src/app/(auth)/verify/page.tsx
@@ -16,8 +16,8 @@ const VerifyUser: React.FC = () => {
 
   useEffect(() => {
     if (verified) {
-      const accessToken = verified?.data?.access_token
-      const refreshToken = verified?.data?.refresh_token
+      const accessToken = verified?.access_token
+      const refreshToken = verified?.refresh_token
 
       signIn('credentials', {
         callbackUrl: '/dashboard',


### PR DESCRIPTION
The reply structure changed and this no longer has a `data` prefix, tested locally and the login proceeds correctly