### PR TITLE
fix: google account type to set session properly

### DIFF
--- a/apps/operator/src/lib/auth/auth.ts
+++ b/apps/operator/src/lib/auth/auth.ts
@@ -11,115 +11,115 @@ import { getTokenFromDatumAPI } from './utils/get-datum-token'
 import { setSessionCookie } from './utils/set-session-cookie'
 
 export const config = {
-  theme: {
-    logo: '/logos/logo_orange_icon.svg',
-  },
-  pages: {
-    signIn: '/login',
-    newUser: '/signup',
-    verifyRequest: '/verify',
-  },
-  session: {
-    strategy: 'jwt',
-  },
-  providers: [
-    GithubProvider({
-      clientId: process.env.AUTH_GITHUB_ID,
-      clientSecret: process.env.AUTH_GITHUB_SECRET,
-    }),
-    GoogleProvider({
-      clientId: process.env.AUTH_GOOGLE_ID,
-      clientSecret: process.env.AUTH_GOOGLE_SECRET,
-    }),
-    credentialsProvider,
-    passKeyProvider,
-  ],
-  callbacks: {
-    async signIn({ user, account }) {
-      // register user that signed in via oauth provider
-      if (account?.type === 'oauth') {
-        const oauthUser = {
-          externalUserID: account?.providerAccountId,
-          name: user.name,
-          email: user.email,
-          image: user.image,
-          authProvider: account?.provider,
-          accessToken: account?.access_token,
-        }
+	theme: {
+		logo: '/logos/logo_orange_icon.svg',
+	},
+	pages: {
+		signIn: '/login',
+		newUser: '/signup',
+		verifyRequest: '/verify',
+	},
+	session: {
+		strategy: 'jwt',
+	},
+	providers: [
+		GithubProvider({
+			clientId: process.env.AUTH_GITHUB_ID,
+			clientSecret: process.env.AUTH_GITHUB_SECRET,
+		}),
+		GoogleProvider({
+			clientId: process.env.AUTH_GOOGLE_ID,
+			clientSecret: process.env.AUTH_GOOGLE_SECRET,
+		}),
+		credentialsProvider,
+		passKeyProvider,
+	],
+	callbacks: {
+		async signIn({ user, account }) {
+			// register user that signed in via oauth provider
+			if (account?.type === 'oauth' || account?.type === 'oidc') {
+				const oauthUser = {
+					externalUserID: account?.providerAccountId,
+					name: user.name,
+					email: user.email,
+					image: user.image,
+					authProvider: account?.provider,
+					accessToken: account?.access_token,
+				}
 
-        const data = await getTokenFromDatumAPI(oauthUser)
+				const data = await getTokenFromDatumAPI(oauthUser)
 
-        // set access token to pull additional data from the API
-        user.accessToken = data?.access_token
-        user.refreshToken = data?.refresh_token
-        user.session = data?.session
+				// set access token to pull additional data from the API
+				user.accessToken = data?.access_token
+				user.refreshToken = data?.refresh_token
+				user.session = data?.session
 
-        // Get user data for sessions
-        const uData = await fetch(`${restUrl}/oauth/userinfo`, {
-          method: 'GET',
-          headers: { Authorization: `Bearer ${user.accessToken}` },
-        })
+				// Get user data for sessions
+				const uData = await fetch(`${restUrl}/oauth/userinfo`, {
+					method: 'GET',
+					headers: { Authorization: `Bearer ${user.accessToken}` },
+				})
 
-        //Save session to cookie
-        setSessionCookie(data?.session)
+				//Save session to cookie
+				setSessionCookie(data?.session)
 
-        if (uData.ok) {
-          const userJson = await uData.json()
-          user.email = userJson?.email
-          user.name = `${userJson?.first_name as string} ${userJson?.last_name as string}`
-          user.image = userJson?.avatar_remote_url
-        }
-      }
+				if (uData.ok) {
+					const userJson = await uData.json()
+					user.email = userJson?.email
+					user.name = `${userJson?.first_name as string} ${userJson?.last_name as string}`
+					user.image = userJson?.avatar_remote_url
+				}
+			}
 
-      return true
-    },
-    jwt({ token, user, account, profile }) {
-      /* 
-      set tokens on user
-      */
-      if (typeof user !== 'undefined') {
-        token.accessToken = user.accessToken
-        token.refreshToken = user.refreshToken
-      } else if (account) {
-        token.accessToken = account.accessToken
-        token.refreshToken = account.refreshToken
-      }
+			return true
+		},
+		jwt({ token, user, account, profile }) {
+			/* 
+			set tokens on user
+			*/
+			if (typeof user !== 'undefined') {
+				token.accessToken = user.accessToken
+				token.refreshToken = user.refreshToken
+			} else if (account) {
+				token.accessToken = account.accessToken
+				token.refreshToken = account.refreshToken
+			}
 
-      if (typeof profile !== 'undefined') {
-        token.name = profile.name ?? token.name
-        token.email = profile.email
-      }
+			if (typeof profile !== 'undefined') {
+				token.name = profile.name ?? token.name
+				token.email = profile.email
+			}
 
-      return token
-    },
-    session: ({ session, token }) => {
-      /**
-       * Here we can persist data into the client-side
-       * session object that is used to read data
-       * from the `useSession` hook in our react client
-       * components
-       *
-       * Note our server components will also see this data
-       * but do not use a client side hook to access it
-       * as that data is memoized in the Node process
-       */
-      if (session.user) {
-        // parse jwt
-        const decodedToken = jwtDecode(
-          token.accessToken as string,
-        ) as JwtPayload
+			return token
+		},
+		session: ({ session, token }) => {
+			/**
+			 * Here we can persist data into the client-side
+			 * session object that is used to read data
+			 * from the `useSession` hook in our react client
+			 * components
+			 *
+			 * Note our server components will also see this data
+			 * but do not use a client side hook to access it
+			 * as that data is memoized in the Node process
+			 */
+			if (session.user) {
+				// parse jwt
+				const decodedToken = jwtDecode(
+					token.accessToken as string,
+				) as JwtPayload
 
-        session.user.name = token.name
-        session.user.email = token.email
-        session.user.accessToken = token.accessToken
-        session.user.refreshToken = token.refreshToken
-        session.user.organization = decodedToken?.org
-        session.user.userId = decodedToken?.user_id
-      }
+				session.user.name = token.name
+				session.user.email = token.email
+				session.user.accessToken = token.accessToken
+				session.user.refreshToken = token.refreshToken
+				session.user.organization = decodedToken?.org
+				session.user.userId = decodedToken?.user_id
+			}
 
-      return session
-    },
-  },
+			return session
+		},
+	},
 } satisfies NextAuthConfig
 
 /**
@@ -127,8 +127,8 @@ export const config = {
  * so that we can reuse them within our app
  */
 export const {
-  handlers: { GET, POST },
-  auth,
-  signIn,
-  signOut,
+	handlers: { GET, POST },
+	auth,
+	signIn,
+	signOut,
 } = NextAuth(config)

--- a/apps/operator/src/lib/auth/auth.ts
+++ b/apps/operator/src/lib/auth/auth.ts
@@ -11,115 +11,115 @@ import { getTokenFromDatumAPI } from './utils/get-datum-token'
 import { setSessionCookie } from './utils/set-session-cookie'
 
 export const config = {
-	theme: {
-		logo: '/logos/logo_orange_icon.svg',
-	},
-	pages: {
-		signIn: '/login',
-		newUser: '/signup',
-		verifyRequest: '/verify',
-	},
-	session: {
-		strategy: 'jwt',
-	},
-	providers: [
-		GithubProvider({
-			clientId: process.env.AUTH_GITHUB_ID,
-			clientSecret: process.env.AUTH_GITHUB_SECRET,
-		}),
-		GoogleProvider({
-			clientId: process.env.AUTH_GOOGLE_ID,
-			clientSecret: process.env.AUTH_GOOGLE_SECRET,
-		}),
-		credentialsProvider,
-		passKeyProvider,
-	],
-	callbacks: {
-		async signIn({ user, account }) {
-			// register user that signed in via oauth provider
-			if (account?.type === 'oauth' || account?.type === 'oidc') {
-				const oauthUser = {
-					externalUserID: account?.providerAccountId,
-					name: user.name,
-					email: user.email,
-					image: user.image,
-					authProvider: account?.provider,
-					accessToken: account?.access_token,
-				}
+  theme: {
+    logo: '/logos/logo_orange_icon.svg',
+  },
+  pages: {
+    signIn: '/login',
+    newUser: '/signup',
+    verifyRequest: '/verify',
+  },
+  session: {
+    strategy: 'jwt',
+  },
+  providers: [
+    GithubProvider({
+      clientId: process.env.AUTH_GITHUB_ID,
+      clientSecret: process.env.AUTH_GITHUB_SECRET,
+    }),
+    GoogleProvider({
+      clientId: process.env.AUTH_GOOGLE_ID,
+      clientSecret: process.env.AUTH_GOOGLE_SECRET,
+    }),
+    credentialsProvider,
+    passKeyProvider,
+  ],
+  callbacks: {
+    async signIn({ user, account }) {
+      // register user that signed in via oauth provider
+      if (account?.type === 'oauth' || account?.type === 'oidc') {
+        const oauthUser = {
+          externalUserID: account?.providerAccountId,
+          name: user.name,
+          email: user.email,
+          image: user.image,
+          authProvider: account?.provider,
+          accessToken: account?.access_token,
+        }
 
-				const data = await getTokenFromDatumAPI(oauthUser)
+        const data = await getTokenFromDatumAPI(oauthUser)
 
-				// set access token to pull additional data from the API
-				user.accessToken = data?.access_token
-				user.refreshToken = data?.refresh_token
-				user.session = data?.session
+        // set access token to pull additional data from the API
+        user.accessToken = data?.access_token
+        user.refreshToken = data?.refresh_token
+        user.session = data?.session
 
-				// Get user data for sessions
-				const uData = await fetch(`${restUrl}/oauth/userinfo`, {
-					method: 'GET',
-					headers: { Authorization: `Bearer ${user.accessToken}` },
-				})
+        // Get user data for sessions
+        const uData = await fetch(`${restUrl}/oauth/userinfo`, {
+          method: 'GET',
+          headers: { Authorization: `Bearer ${user.accessToken}` },
+        })
 
-				//Save session to cookie
-				setSessionCookie(data?.session)
+        //Save session to cookie
+        setSessionCookie(data?.session)
 
-				if (uData.ok) {
-					const userJson = await uData.json()
-					user.email = userJson?.email
-					user.name = `${userJson?.first_name as string} ${userJson?.last_name as string}`
-					user.image = userJson?.avatar_remote_url
-				}
-			}
+        if (uData.ok) {
+          const userJson = await uData.json()
+          user.email = userJson?.email
+          user.name = `${userJson?.first_name as string} ${userJson?.last_name as string}`
+          user.image = userJson?.avatar_remote_url
+        }
+      }
 
-			return true
-		},
-		jwt({ token, user, account, profile }) {
-			/* 
-			set tokens on user
-			*/
-			if (typeof user !== 'undefined') {
-				token.accessToken = user.accessToken
-				token.refreshToken = user.refreshToken
-			} else if (account) {
-				token.accessToken = account.accessToken
-				token.refreshToken = account.refreshToken
-			}
+      return true
+    },
+    jwt({ token, user, account, profile }) {
+      /* 
+      set tokens on user
+      */
+      if (typeof user !== 'undefined') {
+        token.accessToken = user.accessToken
+        token.refreshToken = user.refreshToken
+      } else if (account) {
+        token.accessToken = account.accessToken
+        token.refreshToken = account.refreshToken
+      }
 
-			if (typeof profile !== 'undefined') {
-				token.name = profile.name ?? token.name
-				token.email = profile.email
-			}
+      if (typeof profile !== 'undefined') {
+        token.name = profile.name ?? token.name
+        token.email = profile.email
+      }
 
-			return token
-		},
-		session: ({ session, token }) => {
-			/**
-			 * Here we can persist data into the client-side
-			 * session object that is used to read data
-			 * from the `useSession` hook in our react client
-			 * components
-			 *
-			 * Note our server components will also see this data
-			 * but do not use a client side hook to access it
-			 * as that data is memoized in the Node process
-			 */
-			if (session.user) {
-				// parse jwt
-				const decodedToken = jwtDecode(
-					token.accessToken as string,
-				) as JwtPayload
+      return token
+    },
+    session: ({ session, token }) => {
+      /**
+       * Here we can persist data into the client-side
+       * session object that is used to read data
+       * from the `useSession` hook in our react client
+       * components
+       *
+       * Note our server components will also see this data
+       * but do not use a client side hook to access it
+       * as that data is memoized in the Node process
+       */
+      if (session.user) {
+        // parse jwt
+        const decodedToken = jwtDecode(
+          token.accessToken as string,
+        ) as JwtPayload
 
-				session.user.name = token.name
-				session.user.email = token.email
-				session.user.accessToken = token.accessToken
-				session.user.refreshToken = token.refreshToken
-				session.user.organization = decodedToken?.org
-				session.user.userId = decodedToken?.user_id
-			}
+        session.user.name = token.name
+        session.user.email = token.email
+        session.user.accessToken = token.accessToken
+        session.user.refreshToken = token.refreshToken
+        session.user.organization = decodedToken?.org
+        session.user.userId = decodedToken?.user_id
+      }
 
-			return session
-		},
-	},
+      return session
+    },
+  },
 } satisfies NextAuthConfig
 
 /**
@@ -127,8 +127,8 @@ export const config = {
  * so that we can reuse them within our app
  */
 export const {
-	handlers: { GET, POST },
-	auth,
-	signIn,
-	signOut,
+  handlers: { GET, POST },
+  auth,
+  signIn,
+  signOut,
 } = NextAuth(config)


### PR DESCRIPTION
The access token was not being set correctly in the session because the `google` account type is `oidc`, not `oauth`:

`account output`: 
```
operator:dev: account:  {
operator:dev:   access_token: 'REDACTED',
operator:dev:   expires_in: 3599,
operator:dev:   scope: 'https://www.googleapis.com/auth/userinfo.profile openid https://www.googleapis.com/auth/userinfo.email',
operator:dev:   token_type: 'bearer',
...
operator:dev:   expires_at: 1716593098,
operator:dev:   provider: 'google',
operator:dev:   type: 'oidc',
...
operator:dev: }
```

Should fix this error found in vercel: 
```
[31m[auth][cause][0m: InvalidTokenError: Invalid token specified: must be a string at (../../node_modules/jwt-decode/build/esm/index.js:36:0) at (src/lib/auth/auth.ts:109:10) at (../../node_modules/next-auth/lib/index.js:23:0) at (../../node_modules/@auth/core/lib/actions/session.js:35:0) at (../../node_modules/@auth/core/lib/index.js:35:0) at (../../node_modules/@auth/core/index.js:109:0) at (../../node_modules/next-auth/lib/index.js:126:0) at (../../node_modules/next/dist/esm/server/web/adapter.js:158:0)
```