### PR TITLE
show/hide password registration form

### DIFF
--- a/apps/operator/src/components/pages/auth/signup/signup.tsx
+++ b/apps/operator/src/components/pages/auth/signup/signup.tsx
@@ -183,14 +183,12 @@ export const SignupPage = () => {
                 name="password"
                 placeholder="password"
                 required
-                type="password"
               />
             </div>
             <PasswordInput
               name="confirmedPassword"
               placeholder="confirm password"
               required
-              type="password"
             />
           </>
         )}


### PR DESCRIPTION
In the process of reproducing issue #126, I had to run the command `task install` `task build`, and `task dev:operator`. Notably, while debugging I noticed that component `PasswordInput` in the *signup component* was receiving a `type=password` which was preventing it from updating its' state whenever the eye icon was clicked.

1. signup form with the eye icon not clicked 
![datum-eye-close](https://github.com/datumforge/datum-ui/assets/86970666/ad32afb5-786d-439b-b4df-cc36a3fe3786)

2. signup form with the eye icon clicked to view the password
![datum-eye-open](https://github.com/datumforge/datum-ui/assets/86970666/01292451-e5ae-4dd9-9abd-e84b1f95b7a6)
