### PR TITLE
allow session cookie to be configurable; check for session in middleware

### DIFF
--- a/apps/operator/src/lib/auth/utils/set-session-cookie.ts
+++ b/apps/operator/src/lib/auth/utils/set-session-cookie.ts
@@ -1,10 +1,12 @@
 'use server'
-import { sessionCookieName } from '@repo/dally/auth'
+import { sessionCookieName, sessionCookieExpiration } from '@repo/dally/auth'
 import { cookies } from 'next/headers'
 
 export const setSessionCookie = (session: string): void => {
+  const expirationTime = Number(sessionCookieExpiration) || 1; // default to 60 minutes if not set
+
   const expires = new Date()
-  expires.setDate(expires.getDate() + 7)
+  expires.setTime(expires.getTime() + 1000 * 60 * expirationTime)
 
   if (process.env.NODE_ENV === 'production') {
     cookies().set(`${sessionCookieName}`, session, {
@@ -15,6 +17,8 @@ export const setSessionCookie = (session: string): void => {
       expires,
     })
   } else {
-    cookies().set(`${sessionCookieName}`, session)
+    cookies().set(`${sessionCookieName}`, session, {
+      expires,
+    })
   }
 }

--- a/apps/operator/src/lib/auth/utils/set-session-cookie.ts
+++ b/apps/operator/src/lib/auth/utils/set-session-cookie.ts
@@ -3,7 +3,7 @@ import { sessionCookieName, sessionCookieExpiration } from '@repo/dally/auth'
 import { cookies } from 'next/headers'
 
 export const setSessionCookie = (session: string): void => {
-  const expirationTime = Number(sessionCookieExpiration) || 1; // default to 60 minutes if not set
+  const expirationTime = Number(sessionCookieExpiration) || 60 // default to 60 minutes if not set
 
   const expires = new Date()
   expires.setTime(expires.getTime() + 1000 * 60 * expirationTime)

--- a/apps/operator/src/middleware.ts
+++ b/apps/operator/src/middleware.ts
@@ -5,6 +5,8 @@
 
 import { NextResponse } from 'next/server'
 import { auth } from './lib/auth/auth'
+import { cookies } from 'next/headers'
+import { sessionCookieName } from '@repo/dally/auth'
 
 export default auth((req) => {
   /**
@@ -19,10 +21,22 @@ export default auth((req) => {
    * in the config below.
    *
    * For this example we are just checking that the request
-   * has a valid user attached and if so let the user
+   * has a valid user attached and session cookie and if so let the user
    * continue on, otherwise redirect them to the login page
    */
-  if (req.auth?.user) return NextResponse.next()
+
+  var hasSessionCookie = true
+
+  if (sessionCookieName) {
+    const sessionData = cookies().get(sessionCookieName)
+
+    // if the session cookie is not present, redirect to sign in
+    if (sessionData == null || sessionData.value == "") {
+      hasSessionCookie = false
+    }
+  }
+
+  if (req.auth?.user && hasSessionCookie) return NextResponse.next()
 
   return NextResponse.redirect(new URL('/login', req.url))
 })

--- a/apps/operator/src/middleware.ts
+++ b/apps/operator/src/middleware.ts
@@ -28,13 +28,10 @@ export default auth((req) => {
   var hasSessionCookie = true
 
   if (sessionCookieName) {
-    console.log("getting session cookie", sessionCookieName)
     const sessionData = cookies().get(sessionCookieName)
-    console.log("got session cookie", sessionData)
 
     // if the session cookie is not present, redirect to sign in
     if (sessionData == null || sessionData.value == "") {
-      console.log("no session cookie, will redirect to login")
       hasSessionCookie = false
     }
   }

--- a/apps/operator/src/middleware.ts
+++ b/apps/operator/src/middleware.ts
@@ -28,10 +28,13 @@ export default auth((req) => {
   var hasSessionCookie = true
 
   if (sessionCookieName) {
+    console.log("getting session cookie", sessionCookieName)
     const sessionData = cookies().get(sessionCookieName)
+    console.log("got session cookie", sessionData)
 
     // if the session cookie is not present, redirect to sign in
     if (sessionData == null || sessionData.value == "") {
+      console.log("no session cookie, will redirect to login")
       hasSessionCookie = false
     }
   }

--- a/apps/operator/src/middleware.ts
+++ b/apps/operator/src/middleware.ts
@@ -25,7 +25,7 @@ export default auth((req) => {
    * continue on, otherwise redirect them to the login page
    */
 
-  var hasSessionCookie = true
+  let hasSessionCookie = true
 
   if (sessionCookieName) {
     const sessionData = cookies().get(sessionCookieName)

--- a/config/.env-example
+++ b/config/.env-example
@@ -3,6 +3,7 @@ AUTH_SECRET: $(openssl rand -base64 32)
 API_REST_URL: http://localhost:17608
 NEXT_PUBLIC_API_GQL_URL: http://localhost:17608/query
 SESSION_COOKIE_NAME: temporary-cookie
+SESSION_COOKIE_EXPIRATION_MINUTES: 60
 NOVU_API_KEY: novu-api-key
 NEXT_PUBLIC_NOVU_APP_IDENTIFIER: novu-app-identifier
 

--- a/packages/dally/src/index.ts
+++ b/packages/dally/src/index.ts
@@ -1,3 +1,4 @@
 export const restUrl = process.env.API_REST_URL!
 export const gqlUrl = process.env.NEXT_PUBLIC_API_GQL_URL!
 export const sessionCookieName = process.env.SESSION_COOKIE_NAME
+export const sessionCookieExpiration = process.env.SESSION_COOKIE_EXPIRATION_MINUTES


### PR DESCRIPTION
We were never checking for the datum session cookie, so the user would never be redirected to login if their session was expired, they would just get weird behavior in the UI of some calls not working. This adds the check for the session in the middleware. 

It also allows the cookie expire to be configurable, it shouldn't be 7 days (this is the default in the backend, but the session is only valid in redis for a much shorter time. This allows us to change the cookie expires (it is also updated on subsequent calls by the backend). There will be a follow-up PR for the backend to align the expires. 

Tested this at https://dev-console.datum.net/ and works 