### PR TITLE
fix: setup protected config with a negative include

### DIFF
--- a/apps/operator/src/middleware.ts
+++ b/apps/operator/src/middleware.ts
@@ -43,18 +43,17 @@ export default auth((req) => {
 
 export const config = {
   matcher: [
-    '/',
-    '/assets/:path*',
-    '/billing/:path*',
-    '/configuration/:path*',
-    '/dashboard/:path*',
-    '/workspace/:path*',
-    '/inbox/:path*',
-    '/integrations/:path*',
-    '/people-and-groups/:path*',
-    '/products/:path*',
-    '/revenue/:path*',
-    '/sustainability/:path*',
-    '/tasks-and-mentions/:path*',
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     * and the following unprotected pages:
+     * - login (login page)
+     * - verify (verify page)
+     * - invite (invite verify page)
+     */
+    '\/((?!api|_next\/static|_next\/image|favicon.ico|login|verify|invite).*)',
   ],
 }


### PR DESCRIPTION
The `matcher` list was out of date. Since the list of protected pages is longer than the public pages, I decided to do a negative includes instead.

should resolve https://github.com/datumforge/datum-ui/issues/206