### PR TITLE
fix: regex for images shouldn't redirect to login

### DIFF
--- a/apps/operator/src/middleware.ts
+++ b/apps/operator/src/middleware.ts
@@ -54,6 +54,6 @@ export const config = {
      * - verify (verify page)
      * - invite (invite verify page)
      */
-    '\/((?!api|_next\/static|_next\/image|favicon.ico|login|verify|invite).*)',
+    '\/((?!api|[_next\/static]|[_next\/image]|favicon.ico|login|verify|invite).*)',
   ],
 }

--- a/apps/operator/src/middleware.ts
+++ b/apps/operator/src/middleware.ts
@@ -49,11 +49,13 @@ export const config = {
      * - _next/static (static files)
      * - _next/image (image optimization files)
      * - favicon.ico (favicon file)
+     * - public/backgrounds (background images)
+     * - public/icons (images)
      * and the following unprotected pages:
      * - login (login page)
      * - verify (verify page)
      * - invite (invite verify page)
      */
-    '\/((?!api|[_next\/static]|[_next\/image]|favicon.ico|login|verify|invite).*)',
+    '\/((?!api|[_next\/static]|[_next\/image]|favicon.ico|backgrounds|backgrounds\/|icons|icons\/|login|verify|invite).*)',
   ],
 }


### PR DESCRIPTION
regex 101 says this should work better: 

![image](https://github.com/user-attachments/assets/b6944ece-69f2-40c0-ab14-de2c9e8c6ce2)
